### PR TITLE
Update Rollbar to 5.1.1

### DIFF
--- a/src/Serilog.Sinks.RollbarCom/RollbarSink.cs
+++ b/src/Serilog.Sinks.RollbarCom/RollbarSink.cs
@@ -59,16 +59,15 @@ namespace Serilog
                                        { Server.ReservedProperties.Host, Environment.MachineName },
                                        { Server.ReservedProperties.CodeVersion, Assembly.GetEntryAssembly()?.GetName().Version?.ToString() }
                                    };
-            var rollbarConfig = new RollbarConfig(accessToken) { Transform = transform, ProxyAddress = proxyAddress, Server = serverConfig };
 
-            if (!string.IsNullOrWhiteSpace(environment))
-            {
-                rollbarConfig.Environment = environment;
-            }
+            var rollbarConfig = new RollbarLoggerConfig(accessToken, environment);
+            rollbarConfig.RollbarPayloadManipulationOptions.Reconfigure(new RollbarPayloadManipulationOptions(transform));
+            rollbarConfig.HttpProxyOptions.Reconfigure(new HttpProxyOptions(proxyAddress));
+            rollbarConfig.RollbarPayloadAdditionOptions.Server = serverConfig;
 
             if (scrubFields != null && scrubFields.Length > 0)
             {
-                rollbarConfig.ScrubFields = scrubFields;
+                rollbarConfig.RollbarDataSecurityOptions.Reconfigure(new RollbarDataSecurityOptions { ScrubFields = scrubFields });
             }
 
             if (_asyncLoggingTimeout == default(TimeSpan))

--- a/src/Serilog.Sinks.RollbarCom/Serilog.Sinks.RollbarCom.csproj
+++ b/src/Serilog.Sinks.RollbarCom/Serilog.Sinks.RollbarCom.csproj
@@ -21,8 +21,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.0.0" />
-    <PackageReference Include="Rollbar" Version="2.0.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Rollbar" Version="5.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.RollbarCom/Serilog.Sinks.RollbarCom.csproj
+++ b/src/Serilog.Sinks.RollbarCom/Serilog.Sinks.RollbarCom.csproj
@@ -4,7 +4,7 @@
     <Description>A Rollbar sink for Serilog</Description>
     <VersionPrefix>1.0.3</VersionPrefix>
     <Authors>Oleg Shevchenko</Authors>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Sinks.RollbarCom</AssemblyName>
     


### PR DESCRIPTION
The latest version of Rollbar has [breaking changes](https://docs.rollbar.com/docs/upgrade-paths-across-incompatible-version-changes) surrounding the configuration of the instance. Namely, the `RollbarConfig` class is no longer available and has been replaced with a handful of configuration option types. The changes here should align with the recommended usage [from Rollbar](https://docs.rollbar.com/docs/sdk-usage-how-tos).

I ran a simple test locally to verify items are still showing up in Rollbar, but I have not tested all of the configurations options in these changes (such as `ProxyAddress`, `Server`, and `ScrubFields`).